### PR TITLE
Added configurable imu and pointcloud frames

### DIFF
--- a/config/MID360_config.json
+++ b/config/MID360_config.json
@@ -35,7 +35,9 @@
         "x": 0,
         "y": 0,
         "z": 0
-      }
+      },
+      "imu_frame": "/livox/imu",
+      "pcl_frame": "/livox/pointcloud"
     }
   ]
 }

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -267,6 +267,8 @@ typedef struct {
   ExtParameter extrinsic_param;
   volatile uint32_t set_bits;
   volatile uint32_t get_bits;
+  std::string imu_frame;
+  std::string pcl_frame;
 } UserLivoxLidarConfig;
 
 /** Lidar data source info abstract */

--- a/src/lddc.h
+++ b/src/lddc.h
@@ -72,11 +72,9 @@ class DriverNode;
 class Lddc final {
  public:
 #ifdef BUILDING_ROS1
-  Lddc(int format, int multi_topic, int data_src, int output_type, double frq,
-      std::string &frame_id, bool lidar_bag, bool imu_bag);
+  Lddc(int format, int multi_topic, int data_src, int output_type, double frq, bool lidar_bag, bool imu_bag);
 #elif defined BUILDING_ROS2
-  Lddc(int format, int multi_topic, int data_src, int output_type, double frq,
-      std::string &frame_id);
+  Lddc(int format, int multi_topic, int data_src, int output_type, double frq);
 #endif
   ~Lddc();
 
@@ -100,11 +98,11 @@ class Lddc final {
   void PollingLidarPointCloudData(uint8_t index, LidarDevice *lidar);
   void PollingLidarImuData(uint8_t index, LidarDevice *lidar);
 
-  void PublishPointcloud2(LidarDataQueue *queue, uint8_t index);
-  void PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index);
-  void PublishPclMsg(LidarDataQueue *queue, uint8_t index);
+  void PublishPointcloud2(LidarDataQueue *queue, uint8_t index, const std::string& pcl_frame);
+  void PublishCustomPointcloud(LidarDataQueue *queue, uint8_t index, const std::string& pcl_frame);
+  void PublishPclMsg(LidarDataQueue *queue, uint8_t index, const std::string& pcl_frame);
 
-  void PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index);
+  void PublishImuData(LidarImuDataQueue& imu_data_queue, const uint8_t index, const std::string& imu_frame);
 
   void InitPointcloud2MsgHeader(PointCloud2& cloud);
   void InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp);
@@ -138,7 +136,6 @@ class Lddc final {
   uint8_t output_type_;
   double publish_frq_;
   uint32_t publish_period_ns_;
-  std::string frame_id_;
 
 #ifdef BUILDING_ROS1
   bool enable_lidar_bag_;

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -56,7 +56,6 @@ int main(int argc, char **argv) {
   int data_src = kSourceRawLidar;
   double publish_freq  = 10.0; /* Hz */
   int output_type      = kOutputToRos;
-  std::string frame_id = "livox_frame";
   bool lidar_bag = true;
   bool imu_bag   = false;
 
@@ -65,7 +64,6 @@ int main(int argc, char **argv) {
   livox_node.GetNode().getParam("data_src", data_src);
   livox_node.GetNode().getParam("publish_freq", publish_freq);
   livox_node.GetNode().getParam("output_data_type", output_type);
-  livox_node.GetNode().getParam("frame_id", frame_id);
   livox_node.GetNode().getParam("enable_lidar_bag", lidar_bag);
   livox_node.GetNode().getParam("enable_imu_bag", imu_bag);
 
@@ -83,7 +81,7 @@ int main(int argc, char **argv) {
 
   /** Lidar data distribute control and lidar data source set */
   livox_node.lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type,
-                        publish_freq, frame_id, lidar_bag, imu_bag);
+                        publish_freq, lidar_bag, imu_bag);
   livox_node.lddc_ptr_->SetRosNode(&livox_node);
 
   if (data_src == kSourceRawLidar) {
@@ -126,14 +124,12 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   int data_src = kSourceRawLidar;
   double publish_freq = 10.0; /* Hz */
   int output_type = kOutputToRos;
-  std::string frame_id;
 
   this->declare_parameter("xfer_format", xfer_format);
   this->declare_parameter("multi_topic", 0);
   this->declare_parameter("data_src", data_src);
   this->declare_parameter("publish_freq", 10.0);
   this->declare_parameter("output_data_type", output_type);
-  this->declare_parameter("frame_id", "frame_default");
   this->declare_parameter("user_config_path", "path_default");
   this->declare_parameter("cmdline_input_bd_code", "000000000000001");
   this->declare_parameter("lvx_file_path", "/home/livox/livox_test.lvx");
@@ -143,7 +139,6 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   this->get_parameter("data_src", data_src);
   this->get_parameter("publish_freq", publish_freq);
   this->get_parameter("output_data_type", output_type);
-  this->get_parameter("frame_id", frame_id);
 
   if (publish_freq > 100.0) {
     publish_freq = 100.0;
@@ -156,7 +151,7 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   future_ = exit_signal_.get_future();
 
   /** Lidar data distribute control and lidar data source set */
-  lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq, frame_id);
+  lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq);
   lddc_ptr_->SetRosNode(this);
 
   if (data_src == kSourceRawLidar) {

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -102,6 +102,16 @@ bool LivoxLidarConfigParser::ParseUserConfigs(const rapidjson::Document &doc,
                   << IpNumToString(user_config.handle) << std::endl;
       }
     }
+    if (!config.HasMember("imu_frame")) {
+      user_config.imu_frame = "livox_imu_frame";
+    } else {
+      user_config.imu_frame = std::string(config["imu_frame"].GetString());
+    }
+    if (!config.HasMember("pcl_frame")) {
+      user_config.pcl_frame = "livox_pointcloud_frame";
+    } else {
+      user_config.pcl_frame = std::string(config["pcl_frame"].GetString());
+    }
     user_config.set_bits = 0;
     user_config.get_bits = 0;
 


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for setting custom IMU and pointcloud frame names through the config file.

- **New Features**
  - Added `imu_frame` and `pcl_frame` options to the config.
  - Pointcloud and IMU messages now use these configurable frame names.

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
- Refactored the publishing logic for pointcloud and IMU messages to accept and use configurable frame names, removing reliance on a global or hardcoded frame_id.
- Updated the Lddc class interface and internal methods to propagate per-device frame configuration for IMU and pointcloud topics.
- Modified the configuration parsing logic to read `imu_frame` and `pcl_frame` from the config file, with sensible defaults if not provided.
- Extended the device configuration struct to store these new frame name fields.
- Updated example configuration JSON to show how to specify custom frame names.
- Removed the global `frame_id` parameter from node initialization and configuration.

This PR introduces support for setting custom IMU and pointcloud frame names on a per-device basis via the configuration file. The changes improve flexibility for multi-lidar setups and ensure correct frame association in published ROS messages, enhancing integration with downstream consumers.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lddc.cpp</strong><dd><code>Refactor to support configurable IMU and pointcloud frame names in <br>publishing logic</code></dd></summary>
<hr>

src/lddc.cpp
<li>Refactored pointcloud and IMU publishing methods to accept <br>configurable frame names as parameters.<br> <li> Removed hardcoded and class-level frame_id usage; now uses per-device <br>configuration.<br> <li> Updated internal logic to propagate custom frame names from device <br>config to message headers.<br> <li> Adjusted function signatures and calls to support new frame <br>configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/10xConstruction/livox_ros_driver2/pull/1/files#diff-748583c0cbebc1758485817f9c0b75fc1f1ee4aa4b27abf6f4f2dec298e8747d">+15/-18</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>lddc.h</strong><dd><code>Update Lddc class interface for per-device frame configuration</code>&nbsp; </dd></summary>
<hr>

src/lddc.h
<li>Updated class interface to remove frame_id member variable.<br> <li> Modified constructors and publishing method signatures to accept frame <br>names as parameters.<br> <li> Improved encapsulation of frame configuration per device.<br>


</details>


  </td>
  <td><a href="https://github.com/10xConstruction/livox_ros_driver2/pull/1/files#diff-12d1c1e83e02c1e421e662142cf6fc480393d5f8ecd6222317d7ad4f59a2d4cc">+6/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>comm.h</strong><dd><code>Add imu_frame and pcl_frame fields to device configuration struct</code></dd></summary>
<hr>

src/comm/comm.h
<li>Added imu_frame and pcl_frame string fields to UserLivoxLidarConfig <br>struct.<br> <li> Enables per-device configuration of IMU and pointcloud frame names.<br>


</details>


  </td>
  <td><a href="https://github.com/10xConstruction/livox_ros_driver2/pull/1/files#diff-f37976acfb314a20da8d53ef31e7f37ef01f81ad1061fea465423eabb1c5569f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>livox_ros_driver2.cpp</strong><dd><code>Remove global frame_id parameter and update node/Lddc initialization</code></dd></summary>
<hr>

src/livox_ros_driver2.cpp
<li>Removed global frame_id parameter from node and Lddc instantiation.<br> <li> Updated node parameter declarations and usage to eliminate frame_id.<br> <li> Adjusted Lddc construction to match new interface without frame_id.<br>


</details>


  </td>
  <td><a href="https://github.com/10xConstruction/livox_ros_driver2/pull/1/files#diff-ad56ae34c713d21c9def146db3a11b00fa7d47470a575274ed122c4710605220">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>parse_livox_lidar_cfg.cpp</strong><dd><code>Parse and store configurable IMU and pointcloud frame names from <br>config</code></dd></summary>
<hr>

src/parse_cfg_file/parse_livox_lidar_cfg.cpp
<li>Added parsing logic for imu_frame and pcl_frame from config JSON.<br> <li> Set default frame names if not specified in config.<br> <li> Stores parsed frame names in user_config for each device.<br>


</details>


  </td>
  <td><a href="https://github.com/10xConstruction/livox_ros_driver2/pull/1/files#diff-9e4d74f49729a44ea18384e81bb244925ad8d1f83f7d064c333d56498196ba84">+10/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MID360_config.json</strong><dd><code>Add example imu_frame and pcl_frame fields to device config JSON</code></dd></summary>
<hr>

config/MID360_config.json
<li>Added imu_frame and pcl_frame fields to device configuration example.<br> <li> Demonstrates how to specify custom frame names in config.<br>


</details>


  </td>
  <td><a href="https://github.com/10xConstruction/livox_ros_driver2/pull/1/files#diff-aa3a34ccc8925c415c83115320d1efda404080a8e44cce8aa44f625fd051de4c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying custom frame identifiers for IMU and point cloud data via configuration.
  - If not specified, default frame identifiers will be used for IMU and point cloud messages.

- **Refactor**
  - Simplified the process for assigning frame identifiers by removing the need to set them via parameters and constructors. Frame IDs are now passed directly when publishing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->